### PR TITLE
fix: remove inapplicable error response codes per Commonalities r4.3

### DIFF
--- a/code/API_definitions/application-endpoint-registration.yaml
+++ b/code/API_definitions/application-endpoint-registration.yaml
@@ -506,4 +506,3 @@ components:
       minimum: 1
       maximum: 65535
       example: 8080
-

--- a/code/API_definitions/application-endpoint-registration.yaml
+++ b/code/API_definitions/application-endpoint-registration.yaml
@@ -153,8 +153,6 @@ paths:
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic403"
         "404":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic404"
-        "422":
-          $ref: "#/components/responses/Generic422"
         "429":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic429"
     get:
@@ -189,10 +187,6 @@ paths:
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic401"
         "403":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic403"
-        "404":
-          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic404"
-        "422":
-          $ref: "#/components/responses/Generic422"
         "429":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic429"
 
@@ -236,8 +230,6 @@ paths:
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic403"
         "404":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic404"
-        "422":
-          $ref: "#/components/responses/Generic422"
         "429":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic429"
 
@@ -272,8 +264,6 @@ paths:
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic403"
         "404":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic404"
-        "422":
-          $ref: "#/components/responses/Generic422"
         "429":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic429"
 
@@ -302,8 +292,6 @@ paths:
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic403"
         "404":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic404"
-        "422":
-          $ref: "#/components/responses/Generic422"
         "429":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic429"
 
@@ -519,39 +507,3 @@ components:
       maximum: 65535
       example: 8080
 
-  responses:
-    Generic422:
-      description: Unprocessable Content
-      headers:
-        x-correlator:
-          $ref: "#/components/headers/x-correlator"
-      content:
-        application/json:
-          schema:
-            allOf:
-              - $ref: "../common/CAMARA_common.yaml#/components/schemas/ErrorInfo"
-              - type: object
-                properties:
-                  status:
-                    enum:
-                      - 422
-                  code:
-                    enum:
-                      - SERVICE_NOT_APPLICABLE
-                      - UNIDENTIFIABLE_APPLICATION_PROFILE
-          examples:
-            GENERIC_422_SERVICE_NOT_APPLICABLE:
-              description: Service not applicable for the provided identifier.
-              value:
-                status: 422
-                code: SERVICE_NOT_APPLICABLE
-                message: Service not supported for this applicationProfileId
-            UNIDENTIFIABLE_APPLICATION_PROFILE:
-              description: |
-                The Application Profile is not included in the request
-                and the profile information cannot be derived
-                from the 3-legged access token
-              value:
-                status: 422
-                code: UNIDENTIFIABLE_APPLICATION_PROFILE
-                message: The Application Profile cannot be identified


### PR DESCRIPTION
## Summary

Addresses #46.

- Removed `Generic422` component — `SERVICE_NOT_APPLICABLE` and `UNIDENTIFIABLE_APPLICATION_PROFILE` are not applicable to this API (no device identifier; `UNIDENTIFIABLE_APPLICATION_PROFILE` is not a Commonalities standard code — the scenario is handled by standard `404 NOT_FOUND`)
- Removed `422` from all endpoints
- Removed `404` from `GET /application-endpoint-lists` — listing endpoint with no specific resource lookup

All remaining error codes align with Commonalities r4.3 (0.8.0).